### PR TITLE
Fix bug when array has more than 10 elements

### DIFF
--- a/lib/typhoeus_fix/array_decoder.rb
+++ b/lib/typhoeus_fix/array_decoder.rb
@@ -39,7 +39,7 @@ class Hash
   # @return [TrueClass]
   def im_an_array_typhoeus_encoded?
     return false if self.empty?
-    self.keys.sort == (0...self.keys.size).map{|i|i.to_s}
+    self.keys.map {|k| k.to_i}.sort == (0...self.keys.size).map {|i| i}
   end
 
   # If the hash is an array encoded by typhoeus an array is returned


### PR DESCRIPTION
The alphabetical sort leads to errors when array has more than ten elements. For example
["0", "1", "10", "2", "3", "4", "5", "6", "7", "8", "9"]

This commit fixes the issue by sorting numerically.
